### PR TITLE
fix single file PUT example

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,10 @@ Single file replacement:
 ```json
 // PUT <url>/master/file1
 {
-  "min": 10,
-  "max": 30
+  "fileContent" : {
+    "min": 10,
+    "max": 30
+  }
 }
 ```
 


### PR DESCRIPTION
There should be `fileContent` field at the top level of request body.